### PR TITLE
JsDoc纠正：yd_datetime_leftTime

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,8 +115,8 @@ console.log(validNumber('1.2.')); // 1.20
  * @author 陈随易 <https://chensuiyi.me>
  * @category 日期时间
  * @alias yd_datetime_leftTime
- * @param {Integer} second 剩余时间秒数
- * @returns {Object} 返回剩余时间的不同单位值
+ * @param {number} seconds 剩余时间秒数
+ * @returns {object} 返回剩余时间的不同单位值
  * @summary 这个函数用来根据传入的时间，来计算该时间到当前时间还有多少年、多少月、多少天、等等。
  * @example
  * yd_datetime_leftTime(10000);

--- a/lib/datetime/leftTime.js
+++ b/lib/datetime/leftTime.js
@@ -3,8 +3,8 @@
  * @author 陈随易 <https://chensuiyi.me>
  * @category datetime
  * @alias yd_datetime_leftTime
- * @param {Integer} second 剩余时间秒数
- * @returns {Object} 返回剩余时间的不同单位值
+ * @param {number} seconds 剩余时间秒数
+ * @returns {object} 返回剩余时间的不同单位值
  */
 export default (seconds) => {
     const absTime = Math.abs(seconds);


### PR DESCRIPTION
yd_datetime_leftTime函数的jsdoc中的参数second应该为seconds，类型应为 number。返回值应为 object。
![image](https://github.com/user-attachments/assets/1a093a78-ee51-4d79-8984-7e956201fc8a)
另外readme.md中也有这个错误，我已改正