### PR TITLE
修复: yd_is_chinese 函数, 增加测试: chinese.test.js

### DIFF
--- a/lib/is/chinese.js
+++ b/lib/is/chinese.js
@@ -8,25 +8,23 @@
  * 中文范围：\u2B820-\u2CEAF CJK统一表意文字扩展E区块。
  * 中文范围：\uF900-\uFAFF CJK兼容表意文字区块。
  * 中文范围：\u2F800-\u2FA1F CJK兼容表意文字补充区块。
- * @author go522000 <https://github.com/go522000>
- * @category is
  * @alias yd_is_chinese
- * @summary 判断是否为中文字符串
- * @param {string} str 字符串
- * @param {boolean} isPure 是否纯中文
+ * @category is
  * @returns {boolean} 返回是否是中文字符串
- *
+ * @author go522000 <https://github.com/go522000>
+ * @summary 判断是否为中文字符串
  * @example
  * // 默认匹配纯中文
  * yd_is_chinese('中文'); // true
- *
  * @example
  * // 第二个参数设置为 false，则匹配包含中文的字符串
  * yd_is_chinese('abc中文123', false); // true
+ * @param {string} str 字符串
+ * @param {boolean} isPure 是否纯中文
  */
 export default (str, isPure = true) => {
-    const pureChineseRegex = /^[\u4E00-\u9FFF\u3400-\u4DBF\u20000-\u2A6DF\u2A700-\u2B73F\u2B740-\u2B81F\u2B820-\u2CEAF\uF900-\uFAFF\u2F800-\u2FA1F]+$/;
-    const mixedChineseRegex = /[\u4E00-\u9FFF\u3400-\u4DBF\u20000-\u2A6DF\u2A700-\u2B73F\u2B740-\u2B81F\u2B820-\u2CEAF\uF900-\uFAFF\u2F800-\u2FA1F]/;
+    const pureChineseRegex = /^[\u{4E00}-\u{9FFF}\u{3400}-\u{4DBF}\u{20000}-\u{2A6DF}\u{2A700}-\u{2B73F}\u{2B740}-\u{2B81F}\u{2B820}-\u{2CEAF}\u{F900}-\u{FAFF}\u{2F800}-\u{2FA1F}]+$/u;
+    const mixedChineseRegex = /[\u{4E00}-\u{9FFF}\u{3400}-\u{4DBF}\u{20000}-\u{2A6DF}\u{2A700}-\u{2B73F}\u{2B740}-\u{2B81F}\u{2B820}-\u{2CEAF}\u{F900}-\u{FAFF}\u{2F800}-\u{2FA1F}]/u;
 
     return isPure ? pureChineseRegex.test(str) : mixedChineseRegex.test(str);
 };

--- a/lib/is/chinese.test.js
+++ b/lib/is/chinese.test.js
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import yd_is_chinese from './chinese.js';
+
+describe('yd_is_chinese', () => {
+    it('应该在给定纯中文字符串时返回true', () => {
+        expect(yd_is_chinese('中文')).toBe(true);
+    });
+
+    it('应该在给定包含非中文字符的字符串时返回false', () => {
+        expect(yd_is_chinese('abc中文123')).toBe(false);
+    });
+
+    it('应该在给定包含非中文字符的字符串且isPure为false时返回true', () => {
+        expect(yd_is_chinese('abc中文123', false)).toBe(true);
+    });
+
+    it('应该在给定空字符串时返回false', () => {
+        expect(yd_is_chinese('')).toBe(false);
+    });
+
+    it('应该在给定非字符串参数时返回false', () => {
+        expect(yd_is_chinese(null)).toBe(false);
+        expect(yd_is_chinese(undefined)).toBe(false);
+        expect(yd_is_chinese(123)).toBe(false);
+        expect(yd_is_chinese({})).toBe(false);
+    });
+});


### PR DESCRIPTION
修复 yd_is_chinese 函数没有加入u修饰符，导致正则匹配不正确问题。
增加 yd_is_chinese 的测试实例。