### PR TITLE
新增函数: Sattolo shuffle algorithm

### DIFF
--- a/lib/array/sattoloShuffle.js
+++ b/lib/array/sattoloShuffle.js
@@ -1,0 +1,23 @@
+/**
+ * Sattolo shuffle (Sattolo 洗牌算法）
+ * Sattolo's algorithm is a shuffling algorithm that differs slightly from the standard Fisher-Yates (or Durstenfeld) shuffling algorithm.
+ * @author sikamedia <sikamedia.possu@gmail.com>
+ * @category array
+ * @alias yd_array_sattoloShuffle
+ * @param {Array} array 数组
+ * @returns {Array} Return the array which is a random permutation.
+ * @summary
+ * 1. To generate a random permutation where no element remains in its original position.
+ * 2. To create a random cyclic permutation (where each element moves to a new position).
+ * @example
+ * yd_array_sattoloShuffle([1, 2, 3, 4, 5]);
+ * return (result): [5, 1, 4, 2, 3]
+ */
+export default (array = []) => {
+    const shuffled = [...array];
+    for (let i = shuffled.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * i);
+        [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+    }
+    return shuffled;
+};

--- a/lib/array/sattoloShuffle.test.js
+++ b/lib/array/sattoloShuffle.test.js
@@ -41,7 +41,7 @@ describe('yd_array_sattoloShuffle Sattolo shuffle algorithm', () => {
     it('should produce different permutations', () => {
         const permutations = new Set();
 
-        for (let i = 0; i < 200; i++) {
+        for (let i = 0; i < 1000; i++) {
             permutations.add(JSON.stringify(yd_array_sattoloShuffle(original_arr)));
         }
 

--- a/lib/array/sattoloShuffle.test.js
+++ b/lib/array/sattoloShuffle.test.js
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import yd_array_sattoloShuffle from './sattoloShuffle.js';
+
+describe('yd_array_sattoloShuffle Sattolo shuffle algorithm', () => {
+    let original_arr;
+
+    beforeEach(() => {
+        original_arr = [1, 2, 3, 4, 5];
+    });
+
+    it('should return a new array', () => {
+        const shuffled = yd_array_sattoloShuffle(original_arr);
+        expect(shuffled).not.toBe(original_arr);
+        expect(shuffled).toBeInstanceOf(Array);
+    });
+
+    it('should return an array of the same length', () => {
+        const shuffled = yd_array_sattoloShuffle(original_arr);
+        expect(shuffled).toHaveLength(original_arr.length);
+    });
+
+    it('should contain all the same elements', () => {
+        const shuffled = yd_array_sattoloShuffle(original_arr);
+        expect(shuffled).toEqual(expect.arrayContaining(original_arr));
+        expect(original_arr).toEqual(expect.arrayContaining(shuffled));
+    });
+
+    it('should handle empty arrays', () => {
+        expect(yd_array_sattoloShuffle([])).toEqual([]);
+    });
+
+    it('should handle arrays with one element', () => {
+        expect(yd_array_sattoloShuffle([1])).toEqual([1]);
+    });
+
+    it('should move every element to a new position', () => {
+        const shuffled = yd_array_sattoloShuffle(original_arr);
+        expect(shuffled.every((v, i) => v !== original_arr[i])).toBe(true);
+    });
+
+    it('should produce different permutations', () => {
+        const permutations = new Set();
+
+        for (let i = 0; i < 200; i++) {
+            permutations.add(JSON.stringify(yd_array_sattoloShuffle(original_arr)));
+        }
+
+        // 期望至少产生 23 种不同的排列
+        // The goal is to produce at least 23 different permutations
+        expect(permutations.size).toBeGreaterThan(23);
+    });
+
+    it('should not modify the original array', () => {
+        yd_array_sattoloShuffle(original_arr);
+        expect(original_arr).toEqual([1, 2, 3, 4, 5]);
+    });
+
+    it('should use Math.random', () => {
+        const mockMath = Object.create(global.Math);
+        mockMath.random = vi.fn(() => 0.5);
+        global.Math = mockMath;
+
+        yd_array_sattoloShuffle(original_arr);
+        expect(Math.random).toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
Sattolo's algorithm is a shuffling algorithm that differs slightly from the standard Fisher-Yates (or Durstenfeld) shuffling algorithm. Its main purposes are:

To generate a random permutation where no element remains in its original position.
To create a random cyclic permutation (where each element moves to a new position).
This algorithm is particularly useful in certain specific scenarios, such as:

Creating a secret Santa gift exchange, ensuring no one draws their own name.
In certain games, ensuring each player moves to a new position.
In some algorithmic problems where a random permutation guaranteeing all elements change positions is needed.

Sattolo 算法是一种洗牌算法，但与标准的 Fisher-Yates（或 Durstenfeld）洗牌算法略有不同。其主要用途是：

生成一个随机排列，其中没有元素保持在原位置。
创建一个随机循环排列（每个元素都移动到一个新位置）。
这在某些特定场景下非常有用，例如：

创建一个秘密圣诞老人gift交换，确保没有人抽到自己。
在某些游戏中，确保每个玩家都移动到一个新位置。
在某些算法问题中，需要一个保证所有元素都改变位置的随机排列